### PR TITLE
update build_index_header.py to trigger on Webserver.cpp.o instead of WebServer.o

### DIFF
--- a/build_index_header.py
+++ b/build_index_header.py
@@ -37,7 +37,7 @@ def build_index_html_h(source, target, env):
         f.write("};\n")
         f.write("#endif\n")
 
-env.AddPreAction('$BUILD_DIR/src/WebServer.o', build_index_html_h)
+env.AddPreAction('$BUILD_DIR/src/WebServer.cpp.o', build_index_html_h)
 env.Append(
     CPPPATH = [
         "$BUILD_DIR"


### PR DESCRIPTION
The build wasn't working for me on the Atom version of PlatformIO with 3.5.2rc1. I read through this page to understand how the `build_scripts` works:

http://docs.platformio.org/en/latest/projectconf/advanced_scripting.html

I noticed it references adding a pre trigger action on compiled file names as `file.cpp.o` not `file.o`. I tried making this change and was able to successfully compile.