### PR TITLE
Fixes to RS command

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -144,7 +144,7 @@ COPYRIGHT (c) 2017 Mike Dunston
 // Remote Sensors are enabled by default, the following parameters can be used
 // to control their behavior.
 
-//#define SCAN_REMOTE_SENSORS_ON_STARTUP true
+#define SCAN_REMOTE_SENSORS_ON_STARTUP true
 //#define REMOTE_SENSORS_PREFIX "sensor"
 //#define REMOTE_SENSORS_DECAY 60000
 //#define REMOTE_SENSORS_FIRST_SENSOR 100

--- a/src/RemoteSensors.cpp
+++ b/src/RemoteSensors.cpp
@@ -85,7 +85,7 @@ void RemoteSensorManager::init() {
     if(WiFi.SSID(i).startsWith(REMOTE_SENSORS_PREFIX)) {
       const uint16_t sensorID = String(WiFi.SSID(i)).substring(REMOTE_SENSOR_PREFIX_LEN).toInt();
       log_i("Found RemoteSensor(%d): %s", sensorID, WiFi.SSID(i).c_str());
-      createOrUpdate(sensorsID);
+      createOrUpdate(sensorID, 0);
     }
   }
 #else
@@ -108,9 +108,9 @@ void RemoteSensorManager::createOrUpdate(const uint16_t id, const uint16_t value
 
 bool RemoteSensorManager::remove(const uint16_t id) {
   RemoteSensor *sensorToRemove = NULL;
-  // check for duplicate ID or PIN
+  // check for matching ID or PIN
   for (const auto& sensor : remoteSensors) {
-    if(sensor->getID() == id) {
+    if(sensor->getID() == (id + REMOTE_SENSORS_FIRST_SENSOR) ) {
       sensorToRemove = sensor;
     }
   }
@@ -132,6 +132,19 @@ void RemoteSensorManager::getState(JsonArray &array) {
   }
 }
 
+void RemoteSensorManager::show() {
+  log_i("show sensors");
+  if(remoteSensors.isEmpty()) {
+    wifiInterface.printf(F("<X>"));
+  }
+  else {
+    for (const auto& sensor : remoteSensors) {
+      log_i("show sensor %d", sensor->getID() );
+      sensor->showSensor();
+    }
+  }
+}
+
 RemoteSensor::RemoteSensor(uint16_t id, uint16_t value) :
   Sensor(id + REMOTE_SENSORS_FIRST_SENSOR, -1, false, false), _rawID(id) {
   setSensorValue(value);
@@ -146,19 +159,13 @@ void RemoteSensor::check() {
 }
 
 void RemoteSensor::showSensor() {
-  wifiInterface.printf(F("<RS %d %d>"), getID(), _value);
+  wifiInterface.printf(F("<RS %d %d>"), getID() - REMOTE_SENSORS_FIRST_SENSOR, _value);
 }
 
 void RemoteSensorsCommandAdapter::process(const std::vector<String> arguments) {
   if(arguments.empty()) {
-    // list all sensors
-    if(remoteSensors.isEmpty() == 0) {
-      wifiInterface.printf(F("<X>"));
-    } else {
-      for (const auto& sensor : remoteSensors) {
-        sensor->showSensor();
-      }
-    }
+    // list all sensors 
+    RemoteSensorManager::show();
   } else {
     uint16_t sensorID = arguments[0].toInt();
     if (arguments.size() == 1 && RemoteSensorManager::remove(sensorID)) {


### PR DESCRIPTION
Fixed missing parameter in creation of remoteSensor after optional WiFi scan which caused an error during compilation.  Left WiFi scan in enabled state for you to test.

Made use of REMOTE_SENSORS_FIRST_SENSOR consistent in creation, removal and showing of remoteSensors.

Listing remoteSensors <RS> now works.