### PR TITLE
Expose ability to reset the cached uplink address

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -419,6 +419,7 @@
        <input type="button" id="cs-save-config" value="Save" class='ui-button-inline'/>
        <input type="button" id="cs-factory-reset" value="Factory Reset" class='ui-button-inline'/>
        <input type="button" id="cs-wifi-connect" value="Connect to Network" class='ui-button-inline'/>
+       <input type="button" id="cs-lcc-clear-uplink" value="Reset Uplink Address" class='ui-button-inline'/>
       </div>
      </div>
     </div>
@@ -1151,6 +1152,7 @@ function csConfigUpdate(data) {
  } else {
   $('#cs-wifi-stat-div').hide();
  }
+ $('#cs-lcc-clear-uplink').hide();
 }
 function refreshSSIDList() {
  $('#ssid-connect-confirm').hide();
@@ -1192,6 +1194,11 @@ function refreshSSIDList() {
 }
 function setupConfig() {
  $("#cs-config-tabs").on("tabsactivate", function(event, ui) {
+  if(ui.newTab.text() === 'LCC') {
+   $('#cs-lcc-clear-uplink').show();
+  } else {
+   $('#cs-lcc-clear-uplink').hide();
+  }
   if(ui.newTab.text() === "WiFi") {
    $('#cs-wifi-connect').show();
   } else {
@@ -1226,6 +1233,14 @@ function setupConfig() {
    error : function(xhr, status, error) {showErrorDialog("The command station reported a failure saving configuration data", error);}
   });
  });
+ $('#cs-lcc-clear-uplink').on('vclick', function() {
+  $.ajax({method:'GET',url:'/config?uplink-clear-last=true',
+   beforeSend:function() {showSpinner(String.format('Saving {0} config...', tablist[section]));},
+   complete:hideSpinner,
+   success:function (data, status, xhr) {if(!data.hasOwnProperty('restart')) {csConfigUpdate(data);} else {showSpinner(data.restart, true);}},
+   error:function(xhr, status, error) {showErrorDialog("The command station reported a failure saving configuration data", error);}
+  });
+ })
  $('#cs-wifi-mode').on('change', function() {
   if($("#cs-wifi-mode").val() === 'station' || $("#cs-wifi-mode").val() === 'softap-station') {
    $('#cs-wifi-sta-div').show();

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -289,7 +289,7 @@ public:
                  , CDI_READ_TRIMMED(wifi.tx_power, fd_)
                  , CDI_READ_TRIMMED(wifi.uplink().reconnect, fd_) ? "true" : "false"
                  , wifi.uplink().last_address().ip_address().read(fd_)
-                 , CDI_READ_TRIMMED(wifi.uplink().last_address().ip_address().port)
+                 , CDI_READ_TRIMMED(wifi.uplink().last_address().ip_address().port, fd_)
                  , wifi.uplink().auto_address().service_name().read(fd_).c_str()
                  , wifi.uplink().manual_address().ip_address().read(fd_).c_str()
                  , CDI_READ_TRIMMED(wifi.uplink().manual_address().port, fd_)

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -292,7 +292,7 @@ public:
                  , wifi.uplink().manual_address().ip_address().read(fd_).c_str()
                  , CDI_READ_TRIMMED(wifi.uplink().manual_address().port, fd_)
                  , CDI_READ_TRIMMED(wifi.uplink().search_mode, fd_)
-                 , wifi.uplink().last_address().ip_address().read(fd_)
+                 , wifi.uplink().last_address().ip_address().read(fd_).c_str()
                  , CDI_READ_TRIMMED(wifi.uplink().last_address().port, fd_)
                  , uint64_to_string_hex(ops.event_short().read(fd_)).c_str()
                  , uint64_to_string_hex(ops.event_short_cleared().read(fd_)).c_str()

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -289,7 +289,7 @@ public:
                  , CDI_READ_TRIMMED(wifi.tx_power, fd_)
                  , CDI_READ_TRIMMED(wifi.uplink().reconnect, fd_) ? "true" : "false"
                  , wifi.uplink().last_address().ip_address().read(fd_)
-                 , CDI_READ_TRIMMED(wifi.uplink().last_address().ip_address().port, fd_)
+                 , CDI_READ_TRIMMED(wifi.uplink().last_address().port, fd_)
                  , wifi.uplink().auto_address().service_name().read(fd_).c_str()
                  , wifi.uplink().manual_address().ip_address().read(fd_).c_str()
                  , CDI_READ_TRIMMED(wifi.uplink().manual_address().port, fd_)

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -288,12 +288,12 @@ public:
                  , CDI_READ_TRIMMED(wifi.hub().enable, fd_) ? "true" : "false"
                  , CDI_READ_TRIMMED(wifi.tx_power, fd_)
                  , CDI_READ_TRIMMED(wifi.uplink().reconnect, fd_) ? "true" : "false"
-                 , wifi.uplink().last_address().ip_address().read(fd_)
-                 , CDI_READ_TRIMMED(wifi.uplink().last_address().port, fd_)
                  , wifi.uplink().auto_address().service_name().read(fd_).c_str()
                  , wifi.uplink().manual_address().ip_address().read(fd_).c_str()
                  , CDI_READ_TRIMMED(wifi.uplink().manual_address().port, fd_)
                  , CDI_READ_TRIMMED(wifi.uplink().search_mode, fd_)
+                 , wifi.uplink().last_address().ip_address().read(fd_)
+                 , CDI_READ_TRIMMED(wifi.uplink().last_address().port, fd_)
                  , uint64_to_string_hex(ops.event_short().read(fd_)).c_str()
                  , uint64_to_string_hex(ops.event_short_cleared().read(fd_)).c_str()
                  , uint64_to_string_hex(ops.event_shutdown().read(fd_)).c_str()


### PR DESCRIPTION
The last known uplink address is persisted in a hidden field when reconnect is enabled. This works generally well for most cases but in some cases it results in non-desirable behavior with no clear exit strategy. This commit adds the ability to clear the cached address but does not address an underlying problem with the reconnect strategy where it does not give up trying to reconnect and fallback to mDNS based search after N attempts.