### PR TITLE
Added a Docker-based buildchain.

### DIFF
--- a/buildchain/Dockerfile
+++ b/buildchain/Dockerfile
@@ -1,0 +1,26 @@
+FROM espressif/idf:release-v4.4
+
+# Add group. We chose GID 1000 as default.
+RUN groupadd -g 1000 espressif
+
+# Add user. We chose UID 1000 as default
+RUN useradd espressif -d /home/espressif -u 1000 -g 1000 -m -s /bin/bash
+
+# Copy codebasde
+RUN mkdir /home/espressif/ESP32CommandStation
+COPY . /home/espressif/ESP32CommandStation/
+RUN chown -R espressif:espressif /home/espressif/ESP32CommandStation
+
+# Or, clone it & checkout a specific version
+#USER espressif
+#RUN git clone https://github.com/atanisoft/ESP32CommandStation
+#RUN cd ESP32CommandStation && git pull && git checkout v1.5.0-beta1
+#USER root
+
+# Copy build script & make executable
+COPY buildchain/make_build.sh /home/espressif/make_build.sh
+RUN chmod 755 /home/espressif/make_build.sh
+
+# Move to espressif user and home
+USER espressif
+WORKDIR /home/espressif

--- a/buildchain/artifacts/README.md
+++ b/buildchain/artifacts/README.md
@@ -1,0 +1,1 @@
+Build artifacts will be placed here.

--- a/buildchain/artifacts/README.md
+++ b/buildchain/artifacts/README.md
@@ -1,1 +1,23 @@
-Build artifacts will be placed here.
+## Docker-based buildchain
+
+This is a Docker-based buildchain. It allows to build the firmware with the only requirement of having Docker installed.
+
+
+To start the building procedure, simply run the `build.sh` script:
+
+    ./build.sh 
+
+If no arguments are provided, it will build a firmware for the `esp32` chip type and with the default Command Station settings. The script supports two arguments: the `menuconfig` switch to enable popping up the configuration menu before building, and to set a chip type using the `esp32` or `esp32` switches. For example:
+
+    ./build.sh menuconfig
+
+or
+
+    ./build.sh menuconfig esp32s3
+
+
+Build artifacts (.e. the fiwmware) are placed in the `artifacts` folder.
+
+
+
+A `flash.sh` script is also provided, which requires the `esptool` utility to be installed and that allows to easliy flash the firmware.

--- a/buildchain/build.sh
+++ b/buildchain/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# Startup message
+echo ""
+if [ "x$1" == "xmenuconfig" ]; then
+    echo "Building with custom configuration."
+else
+    echo "Building with default configuration. To change it, run this script with the 'menuconfig' option (i.e. ./build.sh menuconfig)"
+fi
+echo ""
+
+# Move to parent fir in order to allow copying the codebase inside the container
+cd ..
+
+# build the container
+docker build . -f buildchain/Dockerfile -t esp32cs/buildchain
+
+# Build and copy artifacts to the "artifacts" folder
+docker run -v $PWD/buildchain/artifacts:/artifacts -it esp32cs/buildchain /home/espressif/make_build.sh $1
+
+echo ""
+echo "Build complete. To flash, discard the prevoius message and instead use: ./flash.sh serial_port"
+echo ""

--- a/buildchain/build.sh
+++ b/buildchain/build.sh
@@ -1,23 +1,32 @@
 #!/bin/bash
 set -e
 
+# Set chip type
+if [ "x$1" == "xesp32s3" ] || [ "x$2" == "xesp32s3" ]; then
+    CHIP_TYPE=esp32s3
+else
+    CHIP_TYPE=esp32
+fi 
+
 # Startup message
 echo ""
-if [ "x$1" == "xmenuconfig" ]; then
-    echo "Building with custom configuration."
+if [ "x$1" == "xmenuconfig" ] || [ "x$2" == "xmenuconfig" ]; then
+    echo "Building with custom configuration for chip $CHIP_TYPE."
+    CONFIG=menuconfig
 else
-    echo "Building with default configuration. To change it, run this script with the 'menuconfig' option (i.e. ./build.sh menuconfig)"
+    echo "Building with default configuration $CHIP_TYPE.. To change it, run this script with the 'menuconfig' option (i.e. ./build.sh menuconfig)"
+    CONFIG=
 fi
 echo ""
 
-# Move to parent fir in order to allow copying the codebase inside the container
+# Move to parent dir in order to allow copying the codebase inside the container
 cd ..
 
 # build the container
 docker build . -f buildchain/Dockerfile -t esp32cs/buildchain
 
 # Build and copy artifacts to the "artifacts" folder
-docker run -v $PWD/buildchain/artifacts:/artifacts -it esp32cs/buildchain /home/espressif/make_build.sh $1
+docker run -v $PWD/buildchain/artifacts:/artifacts -it esp32cs/buildchain /home/espressif/make_build.sh $CHIP_TYPE $CONFIG
 
 echo ""
 echo "Build complete. To flash, discard the prevoius message and instead use: ./flash.sh serial_port"

--- a/buildchain/flash.sh
+++ b/buildchain/flash.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Port is required
+if [ "x$1" == "x" ]; then
+    echo "Usage: flash.sh serial_port"
+fi 
+
+# Set file locations
+BOOTLOADER_FILE=artifacts/bootloader.bin
+PARTITION_TABLE_FILE=artifacts/partition-table.bin
+DATA_INITIAL_FILE=artifacts/ota_data_initial.bin
+FIRMWARE_FILE=artifacts/ESP32CommandStation.bin
+
+# Flash
+esptool.py -p $1 -b 460800 --before default_reset --after hard_reset --chip esp32  write_flash --flash_mode dio --flash_size detect --flash_freq 40m 0x1000 $BOOTLOADER_FILE 0x8000 $PARTITION_TABLE_FILE 0xe000 $DATA_INITIAL_FILE 0x10000 $FIRMWARE_FILE

--- a/buildchain/flash.sh
+++ b/buildchain/flash.sh
@@ -2,7 +2,9 @@
 
 # Port is required
 if [ "x$1" == "x" ]; then
-    echo "Usage: flash.sh serial_port"
+    echo "Usage: flash.sh serial_port [chip_type]"
+else
+    SERIAL_PORT=$1
 fi 
 
 # Set file locations
@@ -11,5 +13,16 @@ PARTITION_TABLE_FILE=artifacts/partition-table.bin
 DATA_INITIAL_FILE=artifacts/ota_data_initial.bin
 FIRMWARE_FILE=artifacts/ESP32CommandStation.bin
 
+# Set chip type
+echo ""
+if [ "x$2" == "x" ]; then
+    CHIP_TYPE=esp32
+    echo "Using default chip type: esp32"
+else
+    CHIP_TYPE=$2
+    echo "Using chip type: $CHIP_TYPE"
+fi
+echo ""
+
 # Flash
-esptool.py -p $1 -b 460800 --before default_reset --after hard_reset --chip esp32  write_flash --flash_mode dio --flash_size detect --flash_freq 40m 0x1000 $BOOTLOADER_FILE 0x8000 $PARTITION_TABLE_FILE 0xe000 $DATA_INITIAL_FILE 0x10000 $FIRMWARE_FILE
+esptool.py -p $SERIAL_PORT -b 460800 --before default_reset --after hard_reset --chip $CHIP_TYPE  write_flash --flash_mode dio --flash_size detect --flash_freq 40m 0x1000 $BOOTLOADER_FILE 0x8000 $PARTITION_TABLE_FILE 0xe000 $DATA_INITIAL_FILE 0x10000 $FIRMWARE_FILE

--- a/buildchain/make_build.sh
+++ b/buildchain/make_build.sh
@@ -4,8 +4,17 @@ set -e
 # Move to source code folder
 cd /home/espressif/ESP32CommandStation
 
-# Config if required
-if [ "x$1" == "xmenuconfig" ]; then
+# Target if required
+if [ "x$1" == "x" ]; then
+    echo "Missing target"
+    exit 1
+else
+    TARGET=$1
+fi
+idf.py set-target $TARGET
+
+# Config if optional
+if [ "x$2" == "xmenuconfig" ]; then
     idf.py menuconfig
 fi 
 

--- a/buildchain/make_build.sh
+++ b/buildchain/make_build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Move to source code folder
+cd /home/espressif/ESP32CommandStation
+
+# Config if required
+if [ "x$1" == "xmenuconfig" ]; then
+    idf.py menuconfig
+fi 
+
+# Build
+idf.py build
+
+# Copy artifacts
+cp build/bootloader/bootloader.bin /artifacts/
+cp build/partition_table/partition-table.bin /artifacts/
+cp build/ota_data_initial.bin /artifacts/
+cp build/ESP32CommandStation.bin /artifacts/


### PR DESCRIPTION
This is a PR for a Docker-based buildchain.

If invoked with no argument using the `build.sh` script in the `buildchain` folder, it will build the firmware with the default configuration values (and place it in the `artifacts` folder. If instead called with the `menuconfig` argument (`build.sh menuconfig`) it will then pop up the configuration menu before building.

It could be used to provide a simplified building procedure for beginners, or to include it in a CI tool (e.g. GitHub Actions) in order to automatically build a default version of the firmware for each push.

A `flash. sh` script is also provided, which requires `esptool` to be installed on the user computer.

Windows scripts could be added as well in future to make it cross-platform.

